### PR TITLE
Add standard extension for CUDA C/C++ source files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 var fileExists = require('file-exists');
 
 const headerExts = [ '.h', '.hpp', '.hh', '.hxx' ];
-const sourceExts = [ '.c', '.cpp', '.cc', '.cxx', '.m', '.mm' ];
+const sourceExts = [ '.c', '.cpp', '.cc', '.cxx', '.m', '.mm', '.cu' ];
 
 // Generates appropriate variants for the predefined extensions arrays.
 function allExts(exts:string[]) {


### PR DESCRIPTION
Thanks for the great extension!  This is a simple addition so C/C++ programmers working with NVIDIA's very popular CUDA platform can still switch between headers (.h, etc.) and source (typically .cu so you can specify nvcc to compile them).  This works great in conjunction with the vscode-cudacpp extension.  Anyway, this was a big help for me and ought to be useful for many other users out there, so thought I'd open up a PR.  Let me know what you think -- thanks again for writing this!